### PR TITLE
sort後をメソッド参照に修正

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/src/Main.java
+++ b/src/Main.java
@@ -5,13 +5,11 @@ public class Main {
     public static void main(String[] args) {
         List<String> names = List.of("aaa", "bba", "yyy", "abc", "takashi");
 
-        List<String> sortedResult = names.stream().sorted().toList();
+        names.stream().sorted().forEach(System.out::println);
 
         long count = names.stream().filter(name -> name.endsWith("a")).count();
 
         boolean hasA = names.stream().map(String::toUpperCase).anyMatch(name -> name.contains("A"));
-
-        System.out.println(sortedResult);
 
         System.out.println(count);
 


### PR DESCRIPTION
# 概要

↓先日指摘頂いた修正点
>List<String> sortedResult = names.stream().sorted().toList();
ですが、
変数 sortedResultがSystem.out.plintlnで出力するのみの使用であれば、sort後にメソッド参照を用いて一行で記述することができます！

修正を行いました。ご確認をお願いします。

>long countですが、特別理由がない限りint型で問題ないかなと思います

int型に変更するとエラーになってしまい、自分で調べてみた所、longで問題ないといったネットの記事がありました・・・。longのままにしております。問題ないか確認頂けると幸いです。